### PR TITLE
FIX #703 No support for setBinaryStream(int,IS,long)

### DIFF
--- a/src/main/net/sourceforge/jtds/jdbc/JtdsPreparedStatement.java
+++ b/src/main/net/sourceforge/jtds/jdbc/JtdsPreparedStatement.java
@@ -1230,8 +1230,11 @@ public class JtdsPreparedStatement extends JtdsStatement implements PreparedStat
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, long length)
             throws SQLException {
-        // TODO Auto-generated method stub
-        throw new AbstractMethodError();
+        if(length <= Integer.MAX_VALUE) {
+        	setBinaryStream(parameterIndex, x, (int)length);
+        } else {
+            throw new SQLException(Messages.get("error.resultset.longblob"), "24000");        	
+        }
     }
 
     /* (non-Javadoc)
@@ -1250,8 +1253,11 @@ public class JtdsPreparedStatement extends JtdsStatement implements PreparedStat
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream, long length)
             throws SQLException {
-        // TODO Auto-generated method stub
-        throw new AbstractMethodError();
+    	if(length <= Integer.MAX_VALUE) {
+        	setBinaryStream(parameterIndex, inputStream, (int)length);
+        } else {
+            throw new SQLException(Messages.get("error.resultset.longblob"), "24000");
+        }
     }
 
     /* (non-Javadoc)
@@ -1270,8 +1276,11 @@ public class JtdsPreparedStatement extends JtdsStatement implements PreparedStat
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader,
             long length) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new AbstractMethodError();
+		if (length <= Integer.MAX_VALUE) {
+			setCharacterStream(parameterIndex, reader, (int) length);
+		} else {
+			throw new SQLException(Messages.get("error.resultset.longclob"), "24000");
+		}
     }
 
     /* (non-Javadoc)
@@ -1289,8 +1298,11 @@ public class JtdsPreparedStatement extends JtdsStatement implements PreparedStat
     @Override
     public void setClob(int parameterIndex, Reader reader, long length)
             throws SQLException {
-        // TODO Auto-generated method stub
-        throw new AbstractMethodError();
+    	 if(length <= Integer.MAX_VALUE) {
+         	setCharacterStream(parameterIndex, reader, (int)length);
+         } else {
+             throw new SQLException(Messages.get("error.resultset.longclob"), "24000");        	
+         }
     }
 
     /* (non-Javadoc)

--- a/src/main/net/sourceforge/jtds/jdbcx/proxy/PreparedStatementProxy.java
+++ b/src/main/net/sourceforge/jtds/jdbcx/proxy/PreparedStatementProxy.java
@@ -717,8 +717,13 @@ implements PreparedStatement {
      */
     public void setBinaryStream(int parameterIndex, InputStream x, long length)
             throws SQLException {
-        // TODO Auto-generated method stub
-        throw new AbstractMethodError();
+    	 validateConnection();
+
+         try {
+             _preparedStatement.setBinaryStream(parameterIndex, x, length);
+         } catch (SQLException sqlException) {
+             processSQLException(sqlException);
+         }
     }
 
     /* (non-Javadoc)
@@ -735,8 +740,13 @@ implements PreparedStatement {
      */
     public void setBlob(int parameterIndex, InputStream inputStream, long length)
             throws SQLException {
-        // TODO Auto-generated method stub
-        throw new AbstractMethodError();
+    	validateConnection();
+
+        try {
+            _preparedStatement.setBlob(parameterIndex, inputStream, length);
+        } catch (SQLException sqlException) {
+            processSQLException(sqlException);
+        }
     }
 
     /* (non-Javadoc)
@@ -753,8 +763,13 @@ implements PreparedStatement {
      */
     public void setCharacterStream(int parameterIndex, Reader reader,
             long length) throws SQLException {
-        // TODO Auto-generated method stub
-        throw new AbstractMethodError();
+    	validateConnection();
+
+        try {
+            _preparedStatement.setCharacterStream(parameterIndex, reader, length);
+        } catch (SQLException sqlException) {
+            processSQLException(sqlException);
+        }
     }
 
     /* (non-Javadoc)
@@ -770,8 +785,13 @@ implements PreparedStatement {
      */
     public void setClob(int parameterIndex, Reader reader, long length)
             throws SQLException {
-        // TODO Auto-generated method stub
-        throw new AbstractMethodError();
+    	validateConnection();
+
+        try {
+            _preparedStatement.setClob(parameterIndex, reader, length);
+        } catch (SQLException sqlException) {
+            processSQLException(sqlException);
+        }
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
Original ticket - https://sourceforge.net/p/jtds/bugs/703/

> Hibernate 4.1.12 is using setBinaryStream(int,InputStream,long) insteat of setBinaryStream(int,InputStream,int) in order to specify the length of a blob. This does not work with jTDS, as it throws an AbstractMEthodError().
The JDBC4 method sould be implemented, eighter by forwarding to the old method of the size fits into an int, or by generally forwarding the long value, if this can be done easily.

I took a patch of Martin Ball to make that fix, from here https://sourceforge.net/p/jtds/bugs/703/#7c8c :

> I have created a patch for 1.3.1 which forwards the method calls on to the methods which accept the int length. I have reused the same error messages which are used by setBlob(int parameterIndex, Blob x) and setClob(int parameterIndex, Clob x) when the length of the data is > Integer.MAX_VALUE.
> We have only checked that the change for setBinaryStream(int,InputStream,long) is working on our system, not the clob changes. I regret to say that I have not looked at the unit tests as at the moment they are complaining about a missing junit dependency.